### PR TITLE
Added module name to data.classes

### DIFF
--- a/MMM-3Day-Forecast.js
+++ b/MMM-3Day-Forecast.js
@@ -21,8 +21,8 @@ Module.register('MMM-3Day-Forecast', {
         Log.log('Starting module: ' + this.name);
 
         if (this.data.classes === 'MMM-3Day-Forecast') {
-            this.data.classes = 'bright medium';
-            }
+            this.data.classes = 'MMM-3Day-Forecast bright medium';
+        }
 
         // Set up the local values, here we construct the request url to use
         this.units = this.config.units;


### PR DESCRIPTION
The name of the module is required in `this.data.classes` for the Magic Mirror framework to successfully hide and show modules. Not having the module name in said field breaks module visibility management.

This bug was discovered from a user reporting breaking behavior in edward-shen/MMM-pages#8.