### PR TITLE
Solve a race condition when used more than once

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -58,7 +58,7 @@ module.exports = NodeHelper.create({
                 }
 
                 // We have the response figured out so lets fire off the notifiction
-                _this.sendSocketNotification('GOT-3DAY-FORECAST', {'url': _this.url, 'forecast': forecast});
+                _this.sendSocketNotification('GOT-3DAY-FORECAST', {'url': response.request.uri.href, 'forecast': forecast});
             });
         },
 


### PR DESCRIPTION
Solve a race condition caused by MM engine, when the module is used more than once on the page (to show, for example, weather in two different locations).
In such case, `_this` could be of the node_helper of the other module, thus the `url` comes out in the notification not matching the payload, causing the wrong payload to be displayed for the wrong module, and/or the other module stuck on "Loading".

This is caused by the request being caught by the "wrong" node_helper.  Took me considerable debugging to find this one...

So, instead, i changed it to send the actual url stored in the request, attached to the response being analyzed.